### PR TITLE
Modify codelab to use new Preferences API

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
+    implementation "androidx.datastore:datastore-preferences:$dataStoreVersion"
 
     // testing
     testImplementation "junit:junit:$junitVersion"

--- a/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -17,12 +17,21 @@
 package com.codelab.android.datastore.data
 
 import android.content.Context
-import androidx.core.content.edit
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import android.util.Log
+import androidx.datastore.DataStore
+import androidx.datastore.preferences.PreferenceDataStoreFactory
+import androidx.datastore.preferences.Preferences
+import androidx.datastore.preferences.SharedPreferencesMigration
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.File
+import java.io.IOException
 
 private const val USER_PREFERENCES_NAME = "user_preferences"
+private const val USER_PREFERENCES_STORE_FILE_NAME = "user.preferences_pb"
 private const val SORT_ORDER_KEY = "sort_order"
+private const val SHOW_COMPLETED_KEY = "show_completed"
 
 enum class SortOrder {
     NONE,
@@ -31,70 +40,120 @@ enum class SortOrder {
     BY_DEADLINE_AND_PRIORITY
 }
 
+data class UserPreferences(
+    val showCompleted: Boolean,
+    val sortOrder: SortOrder
+)
+
+/**
+ * Extension function on Preferences to easily get the sort order
+ */
+private fun Preferences.getSortOrder(): SortOrder {
+    val order = getString(SORT_ORDER_KEY, SortOrder.NONE.name)
+    return SortOrder.valueOf(order)
+}
+
+/**
+ * Extension function on Preferences to easily set the sort order
+ */
+private fun Preferences.withSortOrder(newSortOrder: SortOrder) =
+    this.toBuilder().setString(SORT_ORDER_KEY, newSortOrder.name).build()
+
 /**
  * Class that handles saving and retrieving user preferences
  */
 class UserPreferencesRepository(context: Context) {
 
-    private val sharedPreferences =
-        context.applicationContext.getSharedPreferences(USER_PREFERENCES_NAME, Context.MODE_PRIVATE)
+    private val TAG: String = "UserPreferencesRepo"
 
-    // Keep the sort order as a stream of changes
-    private val _sortOrderFlow = MutableStateFlow(sortOrder)
-    val sortOrderFlow: StateFlow<SortOrder> = _sortOrderFlow
+    private val dataStore: DataStore<Preferences> by lazy {
+        PreferenceDataStoreFactory().create(
+            produceFile = {
+                File(
+                    context.applicationContext.filesDir,
+                    USER_PREFERENCES_STORE_FILE_NAME
+                )
+            },
+            // Since we're migrating from SharedPreferences, add a migration based on the
+            // SharedPreferences name
+            migrationProducers = listOf(SharedPreferencesMigration(context, USER_PREFERENCES_NAME))
+        )
+    }
 
     /**
-     * Get the sort order. By default, sort order is None.
+     * Get the user preferences flow.
      */
-    private val sortOrder: SortOrder
-        get() {
-            val order = sharedPreferences.getString(SORT_ORDER_KEY, SortOrder.NONE.name)
-            return SortOrder.valueOf(order ?: SortOrder.NONE.name)
+    val userPreferencesFlow: Flow<UserPreferences> = dataStore.data
+        .catch { exception ->
+            // dataStore.data throws an IOException when an error is encountered when reading data
+            if (exception is IOException) {
+                Log.e(TAG, "Error reading preferences.", exception)
+                emit(Preferences.empty())
+            } else {
+                throw exception
+            }
+        }.map { preferences ->
+            // Get the sort order from preferences and convert it to a [SortOrder] object
+            val sortOrder = preferences.getSortOrder()
+            val showCompleted = preferences.getBoolean(SHOW_COMPLETED_KEY, false)
+            UserPreferences(showCompleted, sortOrder)
         }
 
-    fun enableSortByDeadline(enable: Boolean) {
-        val currentOrder = sortOrderFlow.value
-        val newSortOrder =
-            if (enable) {
-                if (currentOrder == SortOrder.BY_PRIORITY) {
-                    SortOrder.BY_DEADLINE_AND_PRIORITY
+    /**
+     * Enable / disable sort by deadline.
+     */
+    suspend fun enableSortByDeadline(enable: Boolean) {
+        // updateData handles data transactionally, ensuring that if the sort is updated at the same
+        // time from another thread, we won't have conflicts
+        dataStore.updateData { currentPreferences ->
+            val currentOrder = currentPreferences.getSortOrder()
+            val newSortOrder =
+                if (enable) {
+                    if (currentOrder == SortOrder.BY_PRIORITY) {
+                        SortOrder.BY_DEADLINE_AND_PRIORITY
+                    } else {
+                        SortOrder.BY_DEADLINE
+                    }
                 } else {
-                    SortOrder.BY_DEADLINE
+                    if (currentOrder == SortOrder.BY_DEADLINE_AND_PRIORITY) {
+                        SortOrder.BY_PRIORITY
+                    } else {
+                        SortOrder.NONE
+                    }
                 }
-            } else {
-                if (currentOrder == SortOrder.BY_DEADLINE_AND_PRIORITY) {
-                    SortOrder.BY_PRIORITY
-                } else {
-                    SortOrder.NONE
-                }
-            }
-        updateSortOrder(newSortOrder)
-        _sortOrderFlow.value = newSortOrder
+            currentPreferences.withSortOrder(newSortOrder)
+        }
     }
 
-    fun enableSortByPriority(enable: Boolean) {
-        val currentOrder = sortOrderFlow.value
-        val newSortOrder =
-            if (enable) {
-                if (currentOrder == SortOrder.BY_DEADLINE) {
-                    SortOrder.BY_DEADLINE_AND_PRIORITY
+    /**
+     * Enable / disable sort by priority.
+     */
+    suspend fun enableSortByPriority(enable: Boolean) {
+        // updateData handles data transactionally, ensuring that if the sort is updated at the same
+        // time from another thread, we won't have conflicts
+        dataStore.updateData { currentPreferences ->
+            val currentOrder = currentPreferences.getSortOrder()
+            val newSortOrder =
+                if (enable) {
+                    if (currentOrder == SortOrder.BY_DEADLINE) {
+                        SortOrder.BY_DEADLINE_AND_PRIORITY
+                    } else {
+                        SortOrder.BY_PRIORITY
+                    }
                 } else {
-                    SortOrder.BY_PRIORITY
+                    if (currentOrder == SortOrder.BY_DEADLINE_AND_PRIORITY) {
+                        SortOrder.BY_DEADLINE
+                    } else {
+                        SortOrder.NONE
+                    }
                 }
-            } else {
-                if (currentOrder == SortOrder.BY_DEADLINE_AND_PRIORITY) {
-                    SortOrder.BY_DEADLINE
-                } else {
-                    SortOrder.NONE
-                }
-            }
-        updateSortOrder(newSortOrder)
-        _sortOrderFlow.value = newSortOrder
+            currentPreferences.withSortOrder(newSortOrder)
+        }
     }
 
-    private fun updateSortOrder(sortOrder: SortOrder) {
-        sharedPreferences.edit {
-            putString(SORT_ORDER_KEY, sortOrder.name)
+    suspend fun updateShowCompleted(showCompleted: Boolean) {
+        dataStore.updateData { currentPreferences ->
+            currentPreferences.toBuilder().setBoolean(SHOW_COMPLETED_KEY, showCompleted).build()
         }
     }
 }

--- a/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -76,6 +76,8 @@ class UserPreferencesRepository(context: Context) {
                 SortOrder.valueOf(
                     preferences[Keys.SORT_ORDER_KEY] ?: SortOrder.NONE.name
                 )
+
+            // Get our show completed value, defaulting to false if not set:
             val showCompleted = preferences[Keys.SHOW_COMPLETED_KEY] ?: false
             UserPreferences(showCompleted, sortOrder)
         }
@@ -86,10 +88,11 @@ class UserPreferencesRepository(context: Context) {
     suspend fun enableSortByDeadline(enable: Boolean) {
         // updateData handles data transactionally, ensuring that if the sort is updated at the same
         // time from another thread, we won't have conflicts
-        dataStore.edit { prefs ->
-            val currentOrder = prefs[Keys.SORT_ORDER_KEY]?.let { SortOrder.valueOf(it) }
+        dataStore.edit { preferences ->
+            val currentOrder =
+                preferences[Keys.SORT_ORDER_KEY]?.let { SortOrder.valueOf(it) }
 
-            val newSortOrder  =
+            val newSortOrder =
                 if (enable) {
                     if (currentOrder == SortOrder.BY_PRIORITY) {
                         SortOrder.BY_DEADLINE_AND_PRIORITY
@@ -104,7 +107,7 @@ class UserPreferencesRepository(context: Context) {
                     }
                 }
 
-            prefs[Keys.SORT_ORDER_KEY] = newSortOrder.name
+            preferences[Keys.SORT_ORDER_KEY] = newSortOrder.name
         }
     }
 
@@ -137,8 +140,8 @@ class UserPreferencesRepository(context: Context) {
     }
 
     suspend fun updateShowCompleted(showCompleted: Boolean) {
-        dataStore.edit { prefs ->
-            prefs[Keys.SHOW_COMPLETED_KEY] = showCompleted
+        dataStore.edit { preferences ->
+            preferences[Keys.SHOW_COMPLETED_KEY] = showCompleted
         }
     }
 }

--- a/app/src/main/java/com/codelab/android/datastore/ui/TasksViewModel.kt
+++ b/app/src/main/java/com/codelab/android/datastore/ui/TasksViewModel.kt
@@ -19,12 +19,14 @@ package com.codelab.android.datastore.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.codelab.android.datastore.data.SortOrder
 import com.codelab.android.datastore.data.Task
 import com.codelab.android.datastore.data.TasksRepository
+import com.codelab.android.datastore.data.UserPreferences
 import com.codelab.android.datastore.data.UserPreferencesRepository
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
 
 data class TasksUiModel(
     val tasks: List<Task>,
@@ -38,23 +40,23 @@ class TasksViewModel(
     private val userPreferencesRepository: UserPreferencesRepository
 ) : ViewModel() {
 
-    // Keep the show completed filter as a stream of changes
-    private val showCompletedFlow = MutableStateFlow(false)
-
-    // Keep the sort order as a stream of changes
-    private val sortOrderFlow = userPreferencesRepository.sortOrderFlow
+    // Keep the user preferences as a stream of changes
+    private val userPreferencesFlow = userPreferencesRepository.userPreferencesFlow
 
     // Every time the sort order, the show completed filter or the list of tasks emit,
     // we should recreate the list of tasks
     private val tasksUiModelFlow = combine(
         repository.tasks,
-        showCompletedFlow,
-        sortOrderFlow
-    ) { tasks: List<Task>, showCompleted: Boolean, sortOrder: SortOrder ->
+        userPreferencesFlow
+    ) { tasks: List<Task>, userPreferences: UserPreferences ->
         return@combine TasksUiModel(
-            tasks = filterSortTasks(tasks, showCompleted, sortOrder),
-            showCompleted = showCompleted,
-            sortOrder = sortOrder
+            tasks = filterSortTasks(
+                tasks,
+                userPreferences.showCompleted,
+                userPreferences.sortOrder
+            ),
+            showCompleted = userPreferences.showCompleted,
+            sortOrder = userPreferences.sortOrder
         )
     }
     val tasksUiModel = tasksUiModelFlow.asLiveData()
@@ -82,15 +84,21 @@ class TasksViewModel(
     }
 
     fun showCompletedTasks(show: Boolean) {
-        showCompletedFlow.value = show
+        viewModelScope.launch {
+            userPreferencesRepository.updateShowCompleted(show)
+        }
     }
 
     fun enableSortByDeadline(enable: Boolean) {
-        userPreferencesRepository.enableSortByDeadline(enable)
+        viewModelScope.launch {
+            userPreferencesRepository.enableSortByDeadline(enable)
+        }
     }
 
     fun enableSortByPriority(enable: Boolean) {
-        userPreferencesRepository.enableSortByPriority(enable)
+        viewModelScope.launch {
+            userPreferencesRepository.enableSortByPriority(enable)
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ ext {
     constraintLayoutVersion = '1.1.3'
     coreVersion = '1.3.1'
     coroutinesVersion = '1.3.7'
+    dataStoreVersion = '1.0.0-alpha01'
     materialVersion = '1.1.0'
     lifecycleVersion = '2.2.0'
 


### PR DESCRIPTION
Changes here:
1. Used the new context.createDataStore() factory function
2. Created the new preferences keys and moved them into a private object in UserPreferencesRepository
3. Used the new map like Preferences API

Also removed the extension functions to keep it streamlined.

Tested by using the locally built preferences and running the app on my phone.