### PR TITLE
Updated preferences api

### DIFF
--- a/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -89,8 +89,8 @@ class UserPreferencesRepository(context: Context) {
         // updateData handles data transactionally, ensuring that if the sort is updated at the same
         // time from another thread, we won't have conflicts
         dataStore.edit { preferences ->
-            val currentOrder =
-                preferences[Keys.SORT_ORDER]?.let { SortOrder.valueOf(it) }
+            val currentOrder = SortOrder.valueOf(
+                preferences[Keys.SORT_ORDER] ?: SortOrder.NONE.name)
 
             val newSortOrder =
                 if (enable) {
@@ -117,8 +117,9 @@ class UserPreferencesRepository(context: Context) {
     suspend fun enableSortByPriority(enable: Boolean) {
         // updateData handles data transactionally, ensuring that if the sort is updated at the same
         // time from another thread, we won't have conflicts
-        dataStore.edit { prefs ->
-            val currentOrder = prefs[Keys.SORT_ORDER]?.let { SortOrder.valueOf(it) }
+        dataStore.edit { preferences ->
+            val currentOrder = SortOrder.valueOf(
+                    preferences[Keys.SORT_ORDER] ?: SortOrder.NONE.name)
 
             val newSortOrder =
                 if (enable) {
@@ -135,7 +136,7 @@ class UserPreferencesRepository(context: Context) {
                     }
                 }
 
-            prefs[Keys.SORT_ORDER] = newSortOrder.name
+            preferences[Keys.SORT_ORDER] = newSortOrder.name
         }
     }
 

--- a/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -54,8 +54,8 @@ class UserPreferencesRepository(context: Context) {
     }
 
     private object Keys {
-        internal val SORT_ORDER_KEY = preferencesKey<String>("sort_order")
-        internal val SHOW_COMPLETED_KEY = preferencesKey<Boolean>("show_completed")
+        internal val SORT_ORDER = preferencesKey<String>("sort_order")
+        internal val SHOW_COMPLETED = preferencesKey<Boolean>("show_completed")
     }
 
     /**
@@ -74,11 +74,11 @@ class UserPreferencesRepository(context: Context) {
             // Get the sort order from preferences and convert it to a [SortOrder] object
             val sortOrder =
                 SortOrder.valueOf(
-                    preferences[Keys.SORT_ORDER_KEY] ?: SortOrder.NONE.name
+                    preferences[Keys.SORT_ORDER] ?: SortOrder.NONE.name
                 )
 
             // Get our show completed value, defaulting to false if not set:
-            val showCompleted = preferences[Keys.SHOW_COMPLETED_KEY] ?: false
+            val showCompleted = preferences[Keys.SHOW_COMPLETED] ?: false
             UserPreferences(showCompleted, sortOrder)
         }
 
@@ -90,7 +90,7 @@ class UserPreferencesRepository(context: Context) {
         // time from another thread, we won't have conflicts
         dataStore.edit { preferences ->
             val currentOrder =
-                preferences[Keys.SORT_ORDER_KEY]?.let { SortOrder.valueOf(it) }
+                preferences[Keys.SORT_ORDER]?.let { SortOrder.valueOf(it) }
 
             val newSortOrder =
                 if (enable) {
@@ -107,7 +107,7 @@ class UserPreferencesRepository(context: Context) {
                     }
                 }
 
-            preferences[Keys.SORT_ORDER_KEY] = newSortOrder.name
+            preferences[Keys.SORT_ORDER] = newSortOrder.name
         }
     }
 
@@ -118,7 +118,7 @@ class UserPreferencesRepository(context: Context) {
         // updateData handles data transactionally, ensuring that if the sort is updated at the same
         // time from another thread, we won't have conflicts
         dataStore.edit { prefs ->
-            val currentOrder = prefs[Keys.SORT_ORDER_KEY]?.let { SortOrder.valueOf(it) }
+            val currentOrder = prefs[Keys.SORT_ORDER]?.let { SortOrder.valueOf(it) }
 
             val newSortOrder =
                 if (enable) {
@@ -135,13 +135,13 @@ class UserPreferencesRepository(context: Context) {
                     }
                 }
 
-            prefs[Keys.SORT_ORDER_KEY] = newSortOrder.name
+            prefs[Keys.SORT_ORDER] = newSortOrder.name
         }
     }
 
     suspend fun updateShowCompleted(showCompleted: Boolean) {
         dataStore.edit { preferences ->
-            preferences[Keys.SHOW_COMPLETED_KEY] = showCompleted
+            preferences[Keys.SHOW_COMPLETED] = showCompleted
         }
     }
 }

--- a/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -97,7 +97,8 @@ class UserPreferencesRepository(context: Context) {
         // time from another thread, we won't have conflicts
         dataStore.edit { preferences ->
             val currentOrder = SortOrder.valueOf(
-                preferences[PreferencesKeys.SORT_ORDER] ?: SortOrder.NONE.name)
+                preferences[PreferencesKeys.SORT_ORDER] ?: SortOrder.NONE.name
+            )
 
             val newSortOrder =
                 if (enable) {
@@ -126,7 +127,8 @@ class UserPreferencesRepository(context: Context) {
         // time from another thread, we won't have conflicts
         dataStore.edit { preferences ->
             val currentOrder = SortOrder.valueOf(
-                    preferences[PreferencesKeys.SORT_ORDER] ?: SortOrder.NONE.name)
+                    preferences[PreferencesKeys.SORT_ORDER] ?: SortOrder.NONE.name
+            )
 
             val newSortOrder =
                 if (enable) {

--- a/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -19,19 +19,13 @@ package com.codelab.android.datastore.data
 import android.content.Context
 import android.util.Log
 import androidx.datastore.DataStore
-import androidx.datastore.preferences.PreferenceDataStoreFactory
-import androidx.datastore.preferences.Preferences
-import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
-import java.io.File
 import java.io.IOException
 
 private const val USER_PREFERENCES_NAME = "user_preferences"
-private const val USER_PREFERENCES_STORE_FILE_NAME = "user.preferences_pb"
-private const val SORT_ORDER_KEY = "sort_order"
-private const val SHOW_COMPLETED_KEY = "show_completed"
 
 enum class SortOrder {
     NONE,
@@ -41,23 +35,9 @@ enum class SortOrder {
 }
 
 data class UserPreferences(
-    val showCompleted: Boolean,
+    val showCompleted: Boolean = false,
     val sortOrder: SortOrder
 )
-
-/**
- * Extension function on Preferences to easily get the sort order
- */
-private fun Preferences.getSortOrder(): SortOrder {
-    val order = getString(SORT_ORDER_KEY, SortOrder.NONE.name)
-    return SortOrder.valueOf(order)
-}
-
-/**
- * Extension function on Preferences to easily set the sort order
- */
-private fun Preferences.withSortOrder(newSortOrder: SortOrder) =
-    this.toBuilder().setString(SORT_ORDER_KEY, newSortOrder.name).build()
 
 /**
  * Class that handles saving and retrieving user preferences
@@ -67,17 +47,15 @@ class UserPreferencesRepository(context: Context) {
     private val TAG: String = "UserPreferencesRepo"
 
     private val dataStore: DataStore<Preferences> by lazy {
-        PreferenceDataStoreFactory().create(
-            produceFile = {
-                File(
-                    context.applicationContext.filesDir,
-                    USER_PREFERENCES_STORE_FILE_NAME
-                )
-            },
-            // Since we're migrating from SharedPreferences, add a migration based on the
-            // SharedPreferences name
-            migrationProducers = listOf(SharedPreferencesMigration(context, USER_PREFERENCES_NAME))
+        context.createDataStore(
+            name = USER_PREFERENCES_NAME,
+            migrations = listOf(SharedPreferencesMigration(context, USER_PREFERENCES_NAME))
         )
+    }
+
+    private object Keys {
+        internal val SORT_ORDER_KEY = preferencesKey<String>("sort_order")
+        internal val SHOW_COMPLETED_KEY = preferencesKey<Boolean>("show_completed")
     }
 
     /**
@@ -88,14 +66,19 @@ class UserPreferencesRepository(context: Context) {
             // dataStore.data throws an IOException when an error is encountered when reading data
             if (exception is IOException) {
                 Log.e(TAG, "Error reading preferences.", exception)
-                emit(Preferences.empty())
+                emit(emptyPreferences())
             } else {
                 throw exception
             }
         }.map { preferences ->
             // Get the sort order from preferences and convert it to a [SortOrder] object
-            val sortOrder = preferences.getSortOrder()
-            val showCompleted = preferences.getBoolean(SHOW_COMPLETED_KEY, false)
+            val sortOrder =
+                SortOrder.valueOf(
+                    preferences[Keys.SORT_ORDER_KEY] ?: SortOrder.NONE.name
+                )
+
+            // Get our show completed value, defaulting to false if not set:
+            val showCompleted = preferences[Keys.SHOW_COMPLETED_KEY] ?: false
             UserPreferences(showCompleted, sortOrder)
         }
 
@@ -105,8 +88,10 @@ class UserPreferencesRepository(context: Context) {
     suspend fun enableSortByDeadline(enable: Boolean) {
         // updateData handles data transactionally, ensuring that if the sort is updated at the same
         // time from another thread, we won't have conflicts
-        dataStore.updateData { currentPreferences ->
-            val currentOrder = currentPreferences.getSortOrder()
+        dataStore.edit { preferences ->
+            val currentOrder =
+                preferences[Keys.SORT_ORDER_KEY]?.let { SortOrder.valueOf(it) }
+
             val newSortOrder =
                 if (enable) {
                     if (currentOrder == SortOrder.BY_PRIORITY) {
@@ -121,7 +106,8 @@ class UserPreferencesRepository(context: Context) {
                         SortOrder.NONE
                     }
                 }
-            currentPreferences.withSortOrder(newSortOrder)
+
+            preferences[Keys.SORT_ORDER_KEY] = newSortOrder.name
         }
     }
 
@@ -131,8 +117,9 @@ class UserPreferencesRepository(context: Context) {
     suspend fun enableSortByPriority(enable: Boolean) {
         // updateData handles data transactionally, ensuring that if the sort is updated at the same
         // time from another thread, we won't have conflicts
-        dataStore.updateData { currentPreferences ->
-            val currentOrder = currentPreferences.getSortOrder()
+        dataStore.edit { prefs ->
+            val currentOrder = prefs[Keys.SORT_ORDER_KEY]?.let { SortOrder.valueOf(it) }
+
             val newSortOrder =
                 if (enable) {
                     if (currentOrder == SortOrder.BY_DEADLINE) {
@@ -147,13 +134,14 @@ class UserPreferencesRepository(context: Context) {
                         SortOrder.NONE
                     }
                 }
-            currentPreferences.withSortOrder(newSortOrder)
+
+            prefs[Keys.SORT_ORDER_KEY] = newSortOrder.name
         }
     }
 
     suspend fun updateShowCompleted(showCompleted: Boolean) {
-        dataStore.updateData { currentPreferences ->
-            currentPreferences.toBuilder().setBoolean(SHOW_COMPLETED_KEY, showCompleted).build()
+        dataStore.edit { preferences ->
+            preferences[Keys.SHOW_COMPLETED_KEY] = showCompleted
         }
     }
 }

--- a/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -54,11 +54,13 @@ class UserPreferencesRepository(context: Context) {
     private val dataStore: DataStore<Preferences> =
         context.createDataStore(
             name = USER_PREFERENCES_NAME,
+            // Since we're migrating from SharedPreferences, add a migration based on the
+            // SharedPreferences name
             migrations = listOf(SharedPreferencesMigration(context, USER_PREFERENCES_NAME))
         )
 
 
-    private object Keys {
+    private object PreferencesKeys {
         val SORT_ORDER = preferencesKey<String>("sort_order")
         val SHOW_COMPLETED = preferencesKey<Boolean>("show_completed")
     }
@@ -79,11 +81,11 @@ class UserPreferencesRepository(context: Context) {
             // Get the sort order from preferences and convert it to a [SortOrder] object
             val sortOrder =
                 SortOrder.valueOf(
-                    preferences[Keys.SORT_ORDER] ?: SortOrder.NONE.name
+                    preferences[PreferencesKeys.SORT_ORDER] ?: SortOrder.NONE.name
                 )
 
             // Get our show completed value, defaulting to false if not set:
-            val showCompleted = preferences[Keys.SHOW_COMPLETED] ?: false
+            val showCompleted = preferences[PreferencesKeys.SHOW_COMPLETED] ?: false
             UserPreferences(showCompleted, sortOrder)
         }
 
@@ -95,7 +97,7 @@ class UserPreferencesRepository(context: Context) {
         // time from another thread, we won't have conflicts
         dataStore.edit { preferences ->
             val currentOrder = SortOrder.valueOf(
-                preferences[Keys.SORT_ORDER] ?: SortOrder.NONE.name)
+                preferences[PreferencesKeys.SORT_ORDER] ?: SortOrder.NONE.name)
 
             val newSortOrder =
                 if (enable) {
@@ -112,7 +114,7 @@ class UserPreferencesRepository(context: Context) {
                     }
                 }
 
-            preferences[Keys.SORT_ORDER] = newSortOrder.name
+            preferences[PreferencesKeys.SORT_ORDER] = newSortOrder.name
         }
     }
 
@@ -124,7 +126,7 @@ class UserPreferencesRepository(context: Context) {
         // time from another thread, we won't have conflicts
         dataStore.edit { preferences ->
             val currentOrder = SortOrder.valueOf(
-                    preferences[Keys.SORT_ORDER] ?: SortOrder.NONE.name)
+                    preferences[PreferencesKeys.SORT_ORDER] ?: SortOrder.NONE.name)
 
             val newSortOrder =
                 if (enable) {
@@ -141,13 +143,13 @@ class UserPreferencesRepository(context: Context) {
                     }
                 }
 
-            preferences[Keys.SORT_ORDER] = newSortOrder.name
+            preferences[PreferencesKeys.SORT_ORDER] = newSortOrder.name
         }
     }
 
     suspend fun updateShowCompleted(showCompleted: Boolean) {
         dataStore.edit { preferences ->
-            preferences[Keys.SHOW_COMPLETED] = showCompleted
+            preferences[PreferencesKeys.SHOW_COMPLETED] = showCompleted
         }
     }
 }

--- a/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -35,7 +35,7 @@ enum class SortOrder {
 }
 
 data class UserPreferences(
-    val showCompleted: Boolean = false,
+    val showCompleted: Boolean,
     val sortOrder: SortOrder
 )
 

--- a/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -46,16 +46,16 @@ class UserPreferencesRepository(context: Context) {
 
     private val TAG: String = "UserPreferencesRepo"
 
-    private val dataStore: DataStore<Preferences> by lazy {
+    private val dataStore: DataStore<Preferences> =
         context.createDataStore(
             name = USER_PREFERENCES_NAME,
             migrations = listOf(SharedPreferencesMigration(context, USER_PREFERENCES_NAME))
         )
-    }
+
 
     private object Keys {
-        internal val SORT_ORDER = preferencesKey<String>("sort_order")
-        internal val SHOW_COMPLETED = preferencesKey<Boolean>("show_completed")
+        val SORT_ORDER = preferencesKey<String>("sort_order")
+        val SHOW_COMPLETED = preferencesKey<Boolean>("show_completed")
     }
 
     /**

--- a/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -19,7 +19,12 @@ package com.codelab.android.datastore.data
 import android.content.Context
 import android.util.Log
 import androidx.datastore.DataStore
-import androidx.datastore.preferences.*
+import androidx.datastore.preferences.Preferences
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.createDataStore
+import androidx.datastore.preferences.edit
+import androidx.datastore.preferences.emptyPreferences
+import androidx.datastore.preferences.preferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map


### PR DESCRIPTION
Changes here:
1) Used the new context.createDataStore() factory function
2) Created the new preferences keys and moved them into a private object in UserPreferencesRepository
3) Used the new map like Preferences API
4) Also removed the extension functions to keep it streamlined.

Tested by using the locally built preferences and running the app on my phone.