### PR TITLE
Updating sorting logic in UserPreferencesRepository

### DIFF
--- a/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/codelab/android/datastore/data/UserPreferencesRepository.kt
@@ -91,6 +91,8 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
                 if (enable) {
                     if (currentOrder == SortOrder.BY_PRIORITY) {
                         SortOrder.BY_DEADLINE_AND_PRIORITY
+                    } else if (currentOrder == SortOrder.BY_DEADLINE_AND_PRIORITY) {
+                        return@edit
                     } else {
                         SortOrder.BY_DEADLINE
                     }
@@ -121,6 +123,8 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
                 if (enable) {
                     if (currentOrder == SortOrder.BY_DEADLINE) {
                         SortOrder.BY_DEADLINE_AND_PRIORITY
+                    } else if (currentOrder == SortOrder.BY_DEADLINE_AND_PRIORITY) {
+                        return@edit
                     } else {
                         SortOrder.BY_PRIORITY
                     }


### PR DESCRIPTION
## Issue 
Fixes https://github.com/googlecodelabs/android-datastore/issues/31

## Description

- Inside enableSortByPriority / enableSortByDeadline methods , checking if the argument is true and SortOrder is already BY_DEADLINE_AND_PRIORITY, perform no updates in preferences.

## Videos

| Before | After|
| -- | -- |
|<img src="https://user-images.githubusercontent.com/808201/120083794-15dbb800-c080-11eb-9381-7af28465731f.gif" height="500" width="260">|<img src="https://user-images.githubusercontent.com/808201/120083798-18d6a880-c080-11eb-9747-0c5cd02f4cbe.gif" height="500" width="260">|