### PR TITLE
Bump versions for Bumblebee

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,12 +20,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.codelab.android.datastore"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
 
@@ -51,13 +51,11 @@ android {
 
 dependencies {
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$supportLibVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "com.google.android.material:material:$materialVersion"
 
     // kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Datastore">
-        <activity android:name=".ui.TasksActivity">
+        <activity android:name=".ui.TasksActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/codelab/android/datastore/ui/TasksActivity.kt
+++ b/app/src/main/java/com/codelab/android/datastore/ui/TasksActivity.kt
@@ -19,7 +19,6 @@ package com.codelab.android.datastore.ui
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.observe
 import androidx.recyclerview.widget.DividerItemDecoration
 import com.codelab.android.datastore.data.SortOrder
 import com.codelab.android.datastore.data.TasksRepository
@@ -42,13 +41,13 @@ class TasksActivity : AppCompatActivity() {
         viewModel = ViewModelProvider(
             this,
             TasksViewModelFactory(TasksRepository, UserPreferencesRepository.getInstance(this))
-        ).get(TasksViewModel::class.java)
+        )[TasksViewModel::class.java]
 
         setupRecyclerView()
         setupFilterListeners(viewModel)
         setupSort()
 
-        viewModel.tasksUiModel.observe(owner = this) { tasksUiModel ->
+        viewModel.tasksUiModel.observe(this) { tasksUiModel ->
             adapter.submitList(tasksUiModel.tasks)
             updateSort(tasksUiModel.sortOrder)
             binding.showCompletedSwitch.isChecked = tasksUiModel.showCompleted

--- a/build.gradle
+++ b/build.gradle
@@ -16,13 +16,13 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.30"
+    ext.kotlin_version = "1.6.10"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -39,15 +39,15 @@ task clean(type: Delete) {
 }
 
 ext {
-    supportLibVersion = '1.3.1'
-    constraintLayoutVersion = '2.1.0'
-    coreVersion = '1.6.0'
-    coroutinesVersion = '1.5.2'
-    materialVersion = '1.4.0'
-    lifecycleVersion = '2.3.1'
+    supportLibVersion = '1.4.1'
+    constraintLayoutVersion = '2.1.3'
+    coreVersion = '1.7.0'
+    coroutinesVersion = '1.6.0'
+    materialVersion = '1.5.0'
+    lifecycleVersion = '2.4.1'
 
     runnerVersion = '1.4.0'
-    rulesVersion = '1.0.1'
-    junitVersion = '4.13.1'
+    rulesVersion = '1.4.0'
+    junitVersion = '4.13.2'
     espressoVersion = '3.4.0'
 }


### PR DESCRIPTION
Updated versions of:
Kotlin, AGP and gradle
compileSDK and targetSDK
dependencies

removed lines:
id 'kotlin-android-extensions'
implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
import androidx.lifecycle.observe

set up:
android:exported="true" in Manifest