### PR TITLE
Bump versions for Bumblebee

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,12 +20,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.codelab.android.datastore"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
 
@@ -52,13 +52,11 @@ android {
 
 dependencies {
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$supportLibVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "com.google.android.material:material:$materialVersion"
 
     // kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Datastore">
-        <activity android:name=".ui.TasksActivity">
+        <activity android:name=".ui.TasksActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,13 +16,13 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.10"
+    ext.kotlin_version = "1.6.10"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.1"
+        classpath "com.android.tools.build:gradle:7.1.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -30,7 +30,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -39,15 +39,15 @@ task clean(type: Delete) {
 }
 
 ext {
-    supportLibVersion = '1.2.0'
-    constraintLayoutVersion = '2.0.2'
-    coreVersion = '1.3.2'
-    coroutinesVersion = '1.3.9'
-    materialVersion = '1.2.1'
+    supportLibVersion = '1.4.1'
+    constraintLayoutVersion = '2.1.3'
+    coreVersion = '1.7.0'
+    coroutinesVersion = '1.6.0'
+    materialVersion = '1.5.0'
     lifecycleVersion = '2.2.0'
 
-    runnerVersion = '1.3.0'
-    rulesVersion = '1.0.1'
-    junitVersion = '4.13'
-    espressoVersion = '3.3.0'
+    runnerVersion = '1.4.0'
+    rulesVersion = '1.4.0'
+    junitVersion = '4.13.2'
+    espressoVersion = '3.4.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip


### PR DESCRIPTION
Updated versions of:
Kotlin, AGP and gradle
compileSDK and targetSDK
dependencies

removed lines:
implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

set up:
android:exported="true" in Manifest

jcenter() replaced with mavenCentral()