### PR TITLE
Delete redundant calling of updateTaskFilters()

### DIFF
--- a/app/src/main/java/com/codelab/android/datastore/ui/TasksActivity.kt
+++ b/app/src/main/java/com/codelab/android/datastore/ui/TasksActivity.kt
@@ -94,7 +94,6 @@ class TasksActivity : AppCompatActivity() {
     private fun observePreferenceChanges() {
         viewModel.tasksUiModel.observe(this) { tasksUiModel ->
             adapter.submitList(tasksUiModel.tasks)
-            updateTaskFilters(tasksUiModel.sortOrder, tasksUiModel.showCompleted)
         }
     }
 


### PR DESCRIPTION
Delete the calling of `updateTaskFilters()` in `observePreferenceChanges()` because it seems redundant.