### PR TITLE
Flamingo proto datastore

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,13 +40,14 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
+    namespace 'com.codelab.android.datastore'
     android.buildFeatures.viewBinding = true
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,12 +21,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.codelab.android.datastore"
         minSdkVersion 16
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id "com.google.protobuf" version "0.8.17"
+    id "com.google.protobuf" version "0.9.2"
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.1'
+        classpath 'com.android.tools.build:gradle:8.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jul 09 14:17:07 BST 2020
+#Fri May 05 10:47:22 KST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-7.2-bin.zip


### PR DESCRIPTION
Make code can run on Android Studio Flamingo
• compileSdkVersion change 32 to 33
• targetSdkVersion 32 to 33
• sourceCompatibility change Java 8 to Java 17
• targetCompatibility change Java 8 to Java 17
• namespace add
• APG change 7.1.1 to 8.0.1
• Gradle change 7.2 to 8.1.1
• "com.google.protobuf" version change "0.8.17" to "0.9.2"