### PR TITLE
Add triggers to .github/workflows/

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,10 +14,10 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     
     - name: set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '11'        
         distribution: 'adopt'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,7 @@
 name: Android CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master, preferences_datastore, proto_datastore ]
   pull_request:


### PR DESCRIPTION
This PR standardizes GitHub Actions triggers in workflow files within `.github/workflows/`.

The goal is to ensure workflows run consistently on `push`, `pull_request`, and `workflow_dispatch` events where appropriate.

This is part of a batch of pull requests across repositories owned by the `android` organization on GitHub.

**Project Owner:** Please review the changes carefully to ensure they are correct and appropriate for this project before approving and merging.

* If you do not think this change is appropriate (e.g., a workflow should NOT run on one of these triggers), please leave a comment explaining why.
* If you think the goal is appropriate but notice a mistake in the implementation, please leave a comment detailing the mistake.
